### PR TITLE
Fixing ValueError 'inhomogeneous shape' due list-array conversion

### DIFF
--- a/lart/datamodules/components/phalp_action_datatset.py
+++ b/lart/datamodules/components/phalp_action_datatset.py
@@ -78,7 +78,7 @@ class PHALP_action_dataset(Dataset):
                                 total_num_tracks=None)
             
             self.data = np.array(self.data)
-            self.track2video = np.array(self.track2video)
+            self.track2video = np.array(self.track2video, dtype=object)
             
             self.data = task_divider(self.data, self.opt.test_batch_id, self.opt.number_of_processes)
             self.track2video = task_divider(self.track2video, self.opt.test_batch_id, self.opt.number_of_processes)


### PR DESCRIPTION
In recent NumPy versions, it is not possible to convert a list of lists with different lengths directly to a NumPy array, causing the following error when someone tries to train LART following the instructions from the official repository.

ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimension. The detected shape was (97148,) + inhomogeneous part.








